### PR TITLE
fix: correct calculateAge method name

### DIFF
--- a/api/Extensions/DateTimeExtensions.cs
+++ b/api/Extensions/DateTimeExtensions.cs
@@ -2,7 +2,7 @@
 {
     public static class DateTimeExtensions
     {
-        public static int calcualteAge(this DateOnly dob) {
+        public static int calculateAge(this DateOnly dob) {
             DateOnly today = DateOnly.FromDateTime(DateTime.Now);
             int age = today.Year - dob.Year;
             if (dob > today.AddYears(-age))

--- a/api/Models/UserModel.cs
+++ b/api/Models/UserModel.cs
@@ -27,7 +27,7 @@ namespace api.Models
         public List<PhotoModel> Photos { get; set; } = [];
         public int GetAge()
         {
-            return DateOfBirth.calcualteAge();
+            return DateOfBirth.calculateAge();
         }
 
 


### PR DESCRIPTION
## Summary
- rename `calcualteAge` extension method to `calculateAge`
- update `GetAge` to call new method name

## Testing
- `dotnet build api/api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0f0d01f883298e708eacfadfa0d7