### PR TITLE
Fix ProductController GetProductById route parameter

### DIFF
--- a/api/Controllers/ProductController.cs
+++ b/api/Controllers/ProductController.cs
@@ -38,7 +38,7 @@ namespace api.Controllers
             }
         }
 
-        [HttpGet("GetProductById{Id}")]
+        [HttpGet("GetProductById/{Id}")]
         public async Task<ActionResult<ProductDto>> GetProductById(Guid Id)
         {
             try {


### PR DESCRIPTION
## Summary
- fix GetProductById route to use slash before Id parameter

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f58ec341c832985a9f0e19cf99b5f